### PR TITLE
fix crlf bug

### DIFF
--- a/src/libclient.c
+++ b/src/libclient.c
@@ -85,7 +85,7 @@ int sendRecvLoop(int sock, const char *msg, int msg_size, int times, int thread_
 	int times_success = 0;
 
 	char expected[strlen(msg) + 3 + 2 + 1];
-	sprintf(expected, "%s%s\r\n", msg, responsePostfix);
+	sprintf(expected, "%s%s", msg, responsePostfix);
 
 	// select用マスクの初期化
 	fd_set mask;
@@ -142,7 +142,15 @@ int sendRecvLoop(int sock, const char *msg, int msg_size, int times, int thread_
 					return times_success;
 				}
 
-				buf[len] = '\0';
+				if (buf[len - 2] == '\r' && buf[len - 1] == '\n')
+				{
+					buf[len - 2] = '\0';
+				}
+				else
+				{
+					buf[len] = '\0';
+				}
+
 				if (strcmp(buf, expected) == 0)
 				{
 					times_success++;


### PR DESCRIPTION
echobackの実装やクライアントの環境依存でベンチマークが失敗してしまうバグが存在している。

---

↓の行のexpectedの実装について
https://github.com/ohkilab/SU-CSexpA-day3-tcpbenchmark/blob/ab916df2c6f16ec0bc927ab55ddd0155615d40c8/src/libclient.c#L88

↑のコードをみるとexpected=msg+"\r\n"としているが、↓ではbufとexpectedを比較してベンチマーク試行の成功可否を判定している
https://github.com/ohkilab/SU-CSexpA-day3-tcpbenchmark/blob/ab916df2c6f16ec0bc927ab55ddd0155615d40c8/src/libclient.c#L146
しかし、サーバ側でechobackを実装したとき、得たものをただ返す場合CRLFを付けないためbuf=msgとなることが予想される。この場合、expectedとbufのCRLFの差でベンチマーク試行が失敗と判定されてしまう。

---

これについて、野口先生と相談の上修正